### PR TITLE
Add an alternative game mode for boss rush

### DIFF
--- a/BossRush/BossRush.cs
+++ b/BossRush/BossRush.cs
@@ -21,6 +21,7 @@ namespace BossRush
         private const string pluginVersion = "0.0.3";
 
         private const string activeKey = "BossRush-active";
+        private const string modeName = "START BOSS RUSH";
 
         public static bool active = false; //is the mod active in current playing session
 
@@ -59,7 +60,7 @@ namespace BossRush
             leftgui = OptionsMenu.leftgui;
             rightgui = OptionsMenu.rightgui;
 
-            AlternativeGameModes.Add("START BOSS RUSH", () =>
+            AlternativeGameModes.Add(modeName, () =>
             {
                 GameSave.currentSave.SetKeyState(activeKey, true);
                 GameSave.currentSave.SetKeyState("cts_bus", true);
@@ -383,7 +384,7 @@ namespace BossRush
 
         public void OnGUI()
         {
-            if (TitleScreen.instance && TitleScreen.instance.saveMenu.HasControl())
+            if (TitleScreen.instance && TitleScreen.instance.saveMenu.HasControl() && AlternativeGameModes.SelectedModeName == modeName)
             {
                 OptionsMenu.OnGUI();
             }

--- a/BossRush/BossRush.cs
+++ b/BossRush/BossRush.cs
@@ -9,6 +9,7 @@ using BepInEx.Logging;
 using HarmonyLib;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using DDoor.AlternativeGameModes;
 
 namespace BossRush
 {
@@ -18,6 +19,8 @@ namespace BossRush
         private const string pluginGuid = "ddoor.BossRush.wijo";
         private const string pluginName = "BossRush";
         private const string pluginVersion = "0.0.3";
+
+        private const string activeKey = "BossRush-active";
 
         public static bool active = false; //is the mod active in current playing session
 
@@ -55,6 +58,12 @@ namespace BossRush
             OptionsMenu.Init();
             leftgui = OptionsMenu.leftgui;
             rightgui = OptionsMenu.rightgui;
+
+            AlternativeGameModes.Add("START BOSS RUSH", () =>
+            {
+                GameSave.currentSave.SetKeyState(activeKey, true);
+                GameSave.currentSave.SetKeyState("cts_bus", true);
+            });
         }
 
         public void FixedUpdate()
@@ -280,15 +289,16 @@ namespace BossRush
         [HarmonyPrefix]
         public static bool FadeInDecimator5000() { if (ignoreNextFadeIn && !active) { ignoreNextFadeIn = false; return false; } return true; }
 
-        [HarmonyPatch(typeof(SaveSlot), "LoadSave")]
-        [HarmonyPrefix]
+
+
+        [HarmonyPatch(typeof(SaveSlot), "useSaveFile")]
+        [HarmonyPostfix]
         public static void PotentialStart(SaveSlot __instance, GameSave ___saveFile)
         {
-            if (__instance.saveId == "slot3")
+            if (___saveFile.IsKeyUnlocked(activeKey))
             {
-                startOnNextLoad = true;
                 active = true;
-                ___saveFile.SetKeyState("cts_bus", true, true);
+                startOnNextLoad = true;
             }
         }
 

--- a/BossRush/BossRush.csproj
+++ b/BossRush/BossRush.csproj
@@ -85,6 +85,9 @@
       <HintPath>Deps\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="AlternativeGameModes">
+      <HintPath>Deps\AlternativeGameModes.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-The usage of the mod is fairly self-explanatory but one note that needs to be said is that to start in rush mode you need to boot file 3. If not, the mod doesn't (or at least shouldn't) have any effect. Have fun!
+To enable boss rush mode, select an empty save slot, then press left or right until
+the START button reads "START BOSS RUSH". An options menu will also appear then.
+
+This mod requires [AlternativeGameModes][] to be also installed.
+
+[AlternativeGameModes]: https://github.com/dpinela/DeathsDoor.AlternativeGameModes


### PR DESCRIPTION
Instead of having to select slot 3 to enable boss rush (and being unable to use slot 3 for anything else), any save slot can now be used by selecting the START BOSS RUSH option in the menu.