### PR TITLE
Fix NMG stat preset

### DIFF
--- a/BossRush/FightStorage.cs
+++ b/BossRush/FightStorage.cs
@@ -120,7 +120,7 @@ namespace BossRush
         public static Dictionary<int, int[]> nmgStatPreset = new Dictionary<int, int[]>() //index = fight where you first have stats (starts at 0 cause list)
         {
             {4, new int[] {2,0,0,0} },
-            {8, new int[] {3,0,0,0} },
+            {7, new int[] {3,0,0,0} },
             {12, new int[] {4,0,0,0} },
             {21, new int[] {5,1,0,0} },
             {23, new int[] {5,2,0,0} }


### PR DESCRIPTION
The NMG stat preset should give strength 3 one fight earlier, at the first crow in mushroom dungeon. Currently you only get the correct stat from the second crow onwards.