### PR TITLE
Spawn position fixes

### DIFF
--- a/BossRush/BossRush.cs
+++ b/BossRush/BossRush.cs
@@ -161,10 +161,10 @@ namespace BossRush
             // toggle jefferson if you're in ava4/steadhone and are using the TE preset
             if (OptionsMenu.stats.texts[OptionsMenu.stats.GetState()] == "teLowHasty") {
                 if (fightsInRun[FightCounter].ToString() == "ava4" || fightsInRun[FightCounter].ToString() == "steadhone") {
-                    save.SetNightState(true);
+                    LightNight.SetNightState(true);
                     JeffersonBackpack.instance.TurnOn();
                 } else {
-                    save.SetNightState(false);
+                    LightNight.SetNightState(false);
                     JeffersonBackpack.instance.TurnOff();
                 }
             }
@@ -307,10 +307,6 @@ namespace BossRush
                 active = true;
                 startOnNextLoad = true;
                 ___saveFile.SetKeyState("cts_bus", true, true);
-
-            if (OptionsMenu.stats.texts[OptionsMenu.stats.GetState()] == "teLowHasty") {
-                ___saveFile.SetNightState(true);
-            }
             }
         }
 

--- a/BossRush/BossRush.cs
+++ b/BossRush/BossRush.cs
@@ -157,6 +157,17 @@ namespace BossRush
                 c.Trigger();
                 c.EndCutscene();
             }
+
+            // toggle jefferson if you're in ava4/steadhone and are using the TE preset
+            if (OptionsMenu.stats.texts[OptionsMenu.stats.GetState()] == "teLowHasty") {
+                if (fightsInRun[FightCounter].ToString() == "ava4" || fightsInRun[FightCounter].ToString() == "steadhone") {
+                    save.SetNightState(true);
+                    JeffersonBackpack.instance.TurnOn();
+                } else {
+                    save.SetNightState(false);
+                    JeffersonBackpack.instance.TurnOff();
+                }
+            }
         }
 
         [HarmonyPatch(typeof(DamageableCharacter), "handleNoHealth")]
@@ -296,6 +307,10 @@ namespace BossRush
                 active = true;
                 startOnNextLoad = true;
                 ___saveFile.SetKeyState("cts_bus", true, true);
+
+            if (OptionsMenu.stats.texts[OptionsMenu.stats.GetState()] == "teLowHasty") {
+                ___saveFile.SetNightState(true);
+            }
             }
         }
 

--- a/BossRush/FightStorage.cs
+++ b/BossRush/FightStorage.cs
@@ -22,7 +22,7 @@ namespace BossRush
             {FightName.lod, new FightData("lvl_HallOfDoors_BOSSFIGHT", new Vector3(-556f, 499f, -45.5f), "BOSS_lord_of_doors NEW") },
             {FightName.steadhone, new FightData("lvl_Graveyard", new Vector3(21.9f, 56.64f, 411.6f), "BOSS_GraveDigger") },
 
-            {FightName.bigPot, new FightData("lvl_GrandmaMansion", new Vector3(-59f, 34f, 1030f), "POT_Mimic_Melee_Big Variant") },
+            {FightName.bigPot, new FightData("lvl_GrandmaMansion", new Vector3(-2.2f, 30.5f, 1036.5f), "POT_Mimic_Melee_Big Variant") }, // Vector3(-59f, 34f, 1030f)
 
             //arenas
 
@@ -57,7 +57,7 @@ namespace BossRush
 
             // avas
             {FightName.ava1, new FightData("AVARICE_WAVES_Mansion", new Vector3(0, 1, 5), "Room_Main/_CONTENTS/EmptyWaveBattle/WaveControl") },
-            {FightName.ava2, new FightData("AVARICE_WAVES_Forest", new Vector3(0, 1, 12.24f), "Room_Main/_CONTENTS/EmptyWaveBattle/WaveControl") },
+            {FightName.ava2, new FightData("AVARICE_WAVES_Forest", new Vector3(0, 1, 5), "Room_Main/_CONTENTS/EmptyWaveBattle/WaveControl") }, // Vector3(0, 1, 12.2f)
             {FightName.ava3, new FightData("AVARICE_WAVES_Fortress", new Vector3(0, 1, 5), "Room_Main/_CONTENTS/EmptyWaveBattle/WaveControl") },
             {FightName.ava4, new FightData("AVARICE_WAVES_Secret", new Vector3(0, 1, 5), "Room_Main/_CONTENTS/EmptyWaveBattle/WaveControl") },
         };

--- a/BossRush/FightStorage.cs
+++ b/BossRush/FightStorage.cs
@@ -22,7 +22,7 @@ namespace BossRush
             {FightName.lod, new FightData("lvl_HallOfDoors_BOSSFIGHT", new Vector3(-556f, 499f, -45.5f), "BOSS_lord_of_doors NEW") },
             {FightName.steadhone, new FightData("lvl_Graveyard", new Vector3(21.9f, 56.64f, 411.6f), "BOSS_GraveDigger") },
 
-            {FightName.bigPot, new FightData("lvl_GrandmaMansion", new Vector3(-2.2f, 30.5f, 1036.5f), "POT_Mimic_Melee_Big Variant") }, // Vector3(-59f, 34f, 1030f)
+            {FightName.bigPot, new FightData("lvl_GrandmaMansion", new Vector3(-65.2f, 34f, 1036f), "POT_Mimic_Melee_Big Variant") }, // Vector3(-59f, 34f, 1030f)
 
             //arenas
 


### PR DESCRIPTION
- Change big pot spawn pos from `(-59f, 34f, 1030f)` to `(-65.2f, 34f, 1036f)` so big pot doesn't peek on spawn, enabling quick kill practice
- Change ava 2 spawn pos from `(0, 1, 12.2f)` to `(0, 1, 5)` to match over avas